### PR TITLE
Fix Permission error that occurs when supervisord runs as rood and ng…

### DIFF
--- a/nginx/docker/nginx.conf
+++ b/nginx/docker/nginx.conf
@@ -41,8 +41,8 @@ http {
     # Logging Settings
     ##
 
-    access_log /proc/self/fd/1;
-    error_log /proc/self/fd/1;
+    access_log stdout;
+    error_log stderr
 
     ##
     # Gzip Settings


### PR DESCRIPTION
…inx as www-data, old config would make nginx try to write directly to the stdout from PID 1 but that would not be allowed. This is also not needed we can write to normal stdout and supervisord will redirect it properly.